### PR TITLE
Able to set Accept Header on File download Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ $response = $api->invoice()->get($entityId);
 $response = $api->invoice()->create($data);
 $response = $api->invoice()->document($entityId); // get document ID
 $response = $api->invoice()->document($entityId, true); // get file content
+$response = $api->invoice()->document($entityId, true, 'image/*'); // accept only images
+$response = $api->invoice()->document($entityId, true, 'application/xml'); // get XRechung XML File (if possible)
 ```
 
 ### Down Payment Invoices Endpoint
@@ -95,6 +97,8 @@ $response = $api->downPaymentInvoice()->get($entityId);
 $response = $api->downPaymentInvoice()->create($data);
 $response = $api->downPaymentInvoice()->document($entityId); // get document ID
 $response = $api->downPaymentInvoice()->document($entityId, true); // get file content
+$response = $api->downPaymentInvoice()->document($entityId, true, 'image/*'); // accept only images
+$response = $api->downPaymentInvoice()->document($entityId, true, 'application/xml'); // get XRechung XML File (if possible)
 ```
 
 ### Order Confirmation Endpoint
@@ -104,6 +108,8 @@ $response = $api->orderConfirmation()->get($entityId);
 $response = $api->orderConfirmation()->create($data);
 $response = $api->orderConfirmation()->document($entityId); // get document ID
 $response = $api->orderConfirmation()->document($entityId, true); // get file content
+$response = $api->orderConfirmation()->document($entityId, true, 'image/*'); // accept only images
+$response = $api->orderConfirmation()->document($entityId, true, 'application/xml'); // get XRechung XML File (if possible)
 ```
 
 ### Quotation Endpoint
@@ -113,6 +119,8 @@ $response = $api->quotation()->get($entityId);
 $response = $api->quotation()->create($data);
 $response = $api->quotation()->document($entityId); // get document ID
 $response = $api->quotation()->document($entityId, true); // get file content
+$response = $api->quotation()->document($entityId, true, 'image/*'); // accept only images
+$response = $api->quotation()->document($entityId, true, 'application/xml'); // get XRechung XML File (if possible)
 ```
 
 ### Voucher Endpoint
@@ -122,6 +130,8 @@ $response = $api->voucher()->create($data);
 $response = $api->voucher()->update($entityId, $data);
 $response = $api->voucher()->document($entityId); // get document ID
 $response = $api->voucher()->document($entityId, true); // get file content
+$response = $api->voucher()->document($entityId, true, 'image/*'); // accept only images
+$response = $api->voucher()->document($entityId, true, 'application/xml'); // get XRechung XML File (if possible)
 $response = $api->voucher()->upload($entitiyId, $filepath);
 ```
 
@@ -133,6 +143,8 @@ $response = $api->creditNote()->get($entityId);
 $response = $api->creditNote()->create($data);
 $response = $api->creditNote()->document($entityId); // get document ID
 $response = $api->creditNote()->document($entityId, true); // get file content
+$response = $api->creditNote()->document($entityId, true, 'image/*'); // accept only images
+$response = $api->creditNote()->document($entityId, true, 'application/xml'); // get XRechung XML File (if possible)
 ```
 
 ### Payment  Endpoint
@@ -221,7 +233,9 @@ $response = $client->getPage(0);
 ### File Endpoint
 ```php
 $response = $api->file()->upload($filePath, $voucherType);
-$response = $api->file()->get($entityId);
+$response = $api->file()->get($entityId); // accept every file
+$response = $api->file()->get($entityId, 'image/*'); // accept only images
+$response = $api->file()->get($entityId, 'application/xml'); // get XRechung XML File (if possible)
 ```
 
 

--- a/src/Api.php
+++ b/src/Api.php
@@ -56,9 +56,11 @@ class Api
 
     public function setRequest(RequestInterface $request): self
     {
-        $request = $request
-            ->withHeader('Authorization', 'Bearer ' . $this->apiKey)
-            ->withHeader('Accept', 'application/json');
+        $request = $request->withHeader('Authorization', 'Bearer ' . $this->apiKey);
+
+        if (!$request->hasHeader('Accept')) {
+            $request = $request->withHeader('Accept', 'application/json');
+        }
 
         if (!$request->hasHeader('Content-Type') && in_array($request->getMethod(), ['POST', 'PUT'], true)) {
             $request = $request->withHeader('Content-Type', 'application/json');

--- a/src/Clients/File.php
+++ b/src/Clients/File.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Sysix\LexOffice\Clients;
 
 use Sysix\LexOffice\BaseClient;
-use Sysix\LexOffice\Clients\Traits\GetTrait;
 use Sysix\LexOffice\Exceptions\LexOfficeApiException;
 use Psr\Http\Message\ResponseInterface;
 use Sysix\LexOffice\Config\FileClientConfig;
@@ -13,9 +12,16 @@ use Sysix\LexOffice\Utils;
 
 class File extends BaseClient
 {
-    use GetTrait;
-
     protected string $resource = 'files';
+
+    public function get(string $id, string $acceptHeader = '*/*'): ResponseInterface
+    {
+        $this->api->newRequest('GET', $this->resource . '/' . rawurlencode($id));
+
+        $this->api->request = $this->api->request->withHeader('Accept', $acceptHeader);
+
+        return $this->api->getResponse();
+    }
 
     /**
      * @throws LexOfficeApiException

--- a/src/Clients/Traits/DocumentClientTrait.php
+++ b/src/Clients/Traits/DocumentClientTrait.php
@@ -11,7 +11,7 @@ use Sysix\LexOffice\Utils;
 
 trait DocumentClientTrait
 {
-    public function document(string $id, bool $asContent = false): ResponseInterface
+    public function document(string $id, bool $asContent = false, string $acceptHeader = '*/*'): ResponseInterface
     {
         $response = $this->api
             ->newRequest('GET', $this->resource . '/' . rawurlencode($id) . '/document')
@@ -34,6 +34,6 @@ trait DocumentClientTrait
 
         $fileClient = new File($this->api);
 
-        return $fileClient->get($content->documentFileId);
+        return $fileClient->get($content->documentFileId, $acceptHeader);
     }
 }

--- a/tests/Clients/FileTest.php
+++ b/tests/Clients/FileTest.php
@@ -21,10 +21,20 @@ class FileTest extends TestClient
         $this->assertInstanceOf(ResponseInterface::class, $response);
 
         $this->assertEquals('GET', $api->request->getMethod());
+        $this->assertEquals('*/*', $api->request->getHeaderLine('Accept'));
         $this->assertEquals(
             $api->apiUrl . '/v1/files/resource-id',
             $api->request->getUri()->__toString()
         );
+    }
+
+    public function testGetWithAccceptHeader(): void
+    {
+        [$api, $stub] = $this->createClientMockObject(File::class);
+
+        $stub->get('resource-id', 'application/xml');
+
+        $this->assertEquals('application/xml', $api->request->getHeaderLine('Accept'));
     }
 
     public function testUploadNotSupportedExtension(): void


### PR DESCRIPTION
## Requirements

- [x] Updated README.md
- [x] Add PHPUnit test
- [x] Added related lexoffice documentation

## Description

It is now possible to download XRechnung or be more specific of the accepted type 

## Related lexoffice documentation

https://developers.lexoffice.io/docs/#files-endpoint-download-a-file