### PR TITLE
chore: change api url to `api.lexware.io`

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -35,7 +35,7 @@ use Sysix\LexOffice\Interfaces\ApiInterface;
 
 class Api implements ApiInterface
 {
-    public string $apiUrl = 'https://api.lexoffice.io';
+    public string $apiUrl = 'https://api.lexware.io';
 
     protected string $apiVersion = 'v1';
 

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -69,7 +69,7 @@ final class ApiTest extends TestClient
             new Response(200, [], 'post-content')
         );
 
-        $this->assertStringStartsWith('api.lexoffice.io', $stub->getRequest()->getUri()->getHost());
+        $this->assertStringStartsWith('api.lexware.io', $stub->getRequest()->getUri()->getHost());
 
         $stub->apiUrl = 'https://test.de';
         $stub->newRequest('POST', 'post-content');


### PR DESCRIPTION
<img width="1215" height="133" alt="grafik" src="https://github.com/user-attachments/assets/0ed3f9f3-cdf3-4ef4-b4c7-2acebb9da36d" />

> Based on our rebranding from lexoffice to Lexware the domains of our app, the API gateway has been changed on 26 May 2025. Please find here the new API Gateway URL for our production system: https://api.lexware.io/. We keep the access to the previously used API Gateway URL available until December 2025.
Nevertheless, for all productive integrations and integrations under development, please use the new URL as soon as possible.